### PR TITLE
feat: add support for setting dns configuration to be pushed to nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ BGP or OSPF.
   Pools, Networks, and Memberships. [ZeroTier Central](https://my.zerotier.com) is our SaaS
   offering, which is driven by the
   [ZeroTier Terraform Provider](https://registry.terraform.io/providers/zerotier/zerotier/latest).
-  
+
 ## Usage
 
 Before we begin, we will need to log into [my.zerotier.com](https://my.zerotier.com) and create an API
@@ -95,6 +95,13 @@ Terraform will perform the following actions:
       + route {
           + target = "10.9.8.0/24"
         }
+      + dns {
+          + domain  = "example.com"
+          + servers = [
+              + "10.10.10.1",
+              + "10.10.10.2",
+            ]
+        }
     }
 
 Plan: 1 to add, 0 to change, 0 to destroy.
@@ -116,7 +123,7 @@ module.this["hello_zerotier"].zerotier_network.this: Creation complete after 1s 
 Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
 ```
 
-Check that it was created in the [ZeroTier Central Webui](my.zerotier.com)  
+Check that it was created in the [ZeroTier Central Webui](my.zerotier.com)
 
 ![](https://i.imgur.com/V5N04ew.png)
 

--- a/examples/setting-dns/README.md
+++ b/examples/setting-dns/README.md
@@ -1,0 +1,25 @@
+# Single Network with DNS configuration
+
+You can set DNS search domain and DNS servers to push to all zerotier nodes via the central API.
+
+A node running the ZeroTier agent will need to run
+```
+zerotier-cli set <networkId> allowDNS=1
+```
+for these settings to be applied
+
+## Usage
+
+To run this example you need to:
+
+First, log into [my.zerotier.com](https://my.zerotier.com) and create an API
+token under the [Account](https://my.zerotier.com/account) section.
+
+Next, export the `ZEROTIER_CENTRAL_TOKEN` variable in your shell or
+Terraform workspace.
+
+```
+terraform init
+terraform plan
+terraform apply
+```

--- a/examples/setting-dns/main.tf
+++ b/examples/setting-dns/main.tf
@@ -1,0 +1,13 @@
+module "this" {
+  for_each    = var.zerotier_networks
+  source      = "../../"
+  name        = each.key
+  description = each.value.description
+  subnets     = each.value.subnets
+  flow_rules  = each.value.flow_rules
+  dns         = each.value.dns
+}
+
+output "this" {
+  value = module.this
+}

--- a/examples/setting-dns/variables.tf
+++ b/examples/setting-dns/variables.tf
@@ -1,0 +1,16 @@
+variable "zerotier_networks" {
+  default = {
+    setting_dns = {
+      description = "Hello Zerotier!"
+      subnets     = ["10.9.76.0/24"]
+      flow_rules  = "accept;"
+      dns = {
+        domain = "example.com"
+        servers = [
+          "10.10.10.1",
+          "10.10.10.2"
+        ]
+      }
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -54,4 +54,9 @@ resource "zerotier_network" "this" {
       via    = route.value.via
     }
   }
+
+  dns {
+    domain  = var.dns.domain
+    servers = var.dns.servers
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,7 @@ output "creation_time" {
 output "id" {
   value = zerotier_network.this.id
 }
+
+output "dns" {
+  value = zerotier_network.this.dns
+}

--- a/variables.tf
+++ b/variables.tf
@@ -83,3 +83,23 @@ variable "subnets" {
   type        = list(string)
   default     = []
 }
+
+variable "dns" {
+  description = "DNS settings to be pushed down to client"
+  type = object({
+    domain  = string
+    servers = list(string)
+  })
+  default = {
+    domain  = ""
+    servers = []
+  }
+  validation {
+    condition     = can([for s in var.dns.servers : cidrnetmask("${s}/32")])
+    error_message = "dns.servers should be a valid IPv4 address."
+  }
+  validation {
+    condition     = var.dns.domain == "" ? true : can(regex("^[a-z0-9]+([\\-\\.]{1}[a-z0-9]+)*\\.[a-z]{2,6}$", var.dns.domain))
+    error_message = "dns.domain should be a valid domain name."
+  }
+}


### PR DESCRIPTION
This PR addresses #2  and adds support for setting the DNS configuration to be pushed to network members, after it has already been added in the underlying provider.

- add support for  setting `dns` block in `zerotier_network` resource
- add example for creation of a network with dns configuration
- update readme to reflect this change.

Note:
While this works just fine, there seems to be a general issue in the underlying provider when it comes to applying DNS configuration to zerotier networks during their creation.
I have opened a corresponding issue: https://github.com/zerotier/terraform-provider-zerotier/issues/43